### PR TITLE
Added status cmd to see node status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,7 @@ logs: 		## display container logs
 setup: 		## setup node for the first time
 	docker-compose run --rm node golemsp run
 
+.PHONY: status
+status: 		## get node status
+	docker-compose exec node golemsp status
+

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The node settings will be kept on your host in a `./data-node` repository.
 ### > Start the Node
 
 Use `make up` to start the node in detached mode. You can access the logs at all time by running `make logs`.
+Use `make status` to see node status.
 
 ## Donation :beer:
 


### PR DESCRIPTION
Thank you for this repo, it is a cleaner way to run the node, specially for beginners.
I have added the status command to run `golemsp status` inside the container.
